### PR TITLE
Created function to delete Searchables when event is deleted

### DIFF
--- a/events/models/events.py
+++ b/events/models/events.py
@@ -173,6 +173,29 @@ def update_event_searchable(event):
 
     searchable.save()
 
+def delete_event_searchable(event):
+    site = Site.objects.get(id=1)
+    event_url = "https://%s%s" % (site.domain, event.get_absolute_url())
+    origin_url = "https://%s%s" % (site.domain, reverse('searchables'))
+
+    md5 = hashlib.md5()
+    federation_url = event_url.split('/')
+    federation_node = '/'.join(federation_url[:3])
+    federation_id = '/'.join(federation_url[:5])
+    md5.update(bytes(federation_id, 'utf8'))
+    event_uri = federation_node + '/' + md5.hexdigest()
+
+    try:
+        searchable = Searchable.objects.get(event_uri=event_uri)
+    except:
+        searchable = Searchable(event_uri)
+        searchable.origin_node = origin_url
+        searchable.federation_node = origin_url
+        searchable.federation_time = timezone.now()
+
+    searchable.event_url = event_url
+    searchable.delete()
+
 def slugify(s, ok=SLUG_OK, lower=True, spaces=False):
     # L and N signify letter/number.
     # http://www.unicode.org/reports/tr44/tr44-4.html#GC_Values_Table

--- a/events/models/events.py
+++ b/events/models/events.py
@@ -187,14 +187,10 @@ def delete_event_searchable(event):
 
     try:
         searchable = Searchable.objects.get(event_uri=event_uri)
+        searchable.delete()
     except:
-        searchable = Searchable(event_uri)
-        searchable.origin_node = origin_url
-        searchable.federation_node = origin_url
-        searchable.federation_time = timezone.now()
+        pass
 
-    searchable.event_url = event_url
-    searchable.delete()
 
 def slugify(s, ok=SLUG_OK, lower=True, spaces=False):
     # L and N signify letter/number.

--- a/get_together/views/events.py
+++ b/get_together/views/events.py
@@ -7,7 +7,8 @@ from django.shortcuts import render, redirect, reverse, get_object_or_404
 from django.http import HttpResponse, JsonResponse
 from django.utils import timezone
 
-from events.models.events import Event, CommonEvent, EventSeries, EventPhoto, Place, Attendee
+from events.models.events import Event, CommonEvent, EventSeries, EventPhoto, Place, Attendee, update_event_searchable, \
+    delete_event_searchable
 from events.models.profiles import Team, Organization, UserProfile, Member
 from events.forms import (
     TeamEventForm,
@@ -276,6 +277,7 @@ def delete_event(request, event_id):
         form = DeleteEventForm(request.POST)
         if form.is_valid() and form.cleaned_data['confirm']:
             team_id = event.team_id
+            delete_event_searchable(event);
             event.delete()
             return redirect('show-team', team_id)
         else:


### PR DESCRIPTION
Solving issue #77 

Added the function
delete_event_searchable

in events\model\events.py, which deletes the searchable for an event, and called that function in

get_together\views\events.py

in the delete_event function to delete the searchable for the event before deleting the event