### PR TITLE
Fix broken translations markup on homepage when no events found. 

### DIFF
--- a/get_together/templates/get_together/index.html
+++ b/get_together/templates/get_together/index.html
@@ -53,9 +53,9 @@
                         {% else %}
                             {% blocktrans %}There are no events within {{ distance }}km of you.{% endblocktrans %}
                         {% endif %}
-                        <a class="btn btn-success btn-sm" href="{% url 'create-event-team-select' %}">trans "Create one now" %}</a>
+                        <a class="btn btn-success btn-sm" href="{% url 'create-event-team-select' %}">{% trans "Create one now" %}</a>
                         or
-                        <a class="btn btn-primary btn-sm" href="{% url 'all-events' %}">trans "View all events" %}</a>
+                        <a class="btn btn-primary btn-sm" href="{% url 'all-events' %}">{% trans "View all events" %}</a>
                     </div>
                 </div>
             {% endif %}

--- a/get_together/tests/views.py
+++ b/get_together/tests/views.py
@@ -57,6 +57,8 @@ class ViewTests(TestCase):
         if not response.status_code == status:
             print("check_view(%s) returned %s" % (url, response.status_code))
         assert(response.status_code == status)
+        if response.status_code == 200:
+            self.assertContains(response, 'trans', 0)
 
     def test_teams_list(self): 
         self.check_view('/teams/', login=True)


### PR DESCRIPTION
Update test suite to check for 'trans' in HTML response