### PR TITLE
[BUGFIX] Make account setup link absolute

### DIFF
--- a/get_together/settings.py
+++ b/get_together/settings.py
@@ -60,7 +60,7 @@ INSTALLED_APPS = [
 
 LOGIN_URL = 'login'
 LOGOUT_URL = 'logout'
-SETUP_URL = 'profile/+confirm_profile'
+SETUP_URL = '/profile/+confirm_profile'
 LOGIN_REDIRECT_URL = 'home'
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',


### PR DESCRIPTION
The link to setup an account is relative, therefore all setup links on subpages will fail.

Make the link absolute to avoid this behaviour.

Refs #175