### PR TITLE
Basic spam control when emailing to unknown addresses

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -58,6 +58,16 @@ class Account(models.Model):
             print(e)
             return False
 
+    def remaining_emails_allowed(self):
+        recently_sent = EmailRecord.objects.filter(
+            sender=self.user,
+            when__gte=datetime.datetime.now() - datetime.timedelta(hours=24),
+        ).count()
+        if recently_sent < settings.ALLOWED_EMAILS_PER_DAY:
+            return settings.ALLOWED_EMAILS_PER_DAY - recently_sent
+        else:
+            return 0
+
     def __str__(self):
         try:
             if self.acctname:

--- a/get_together/settings.py
+++ b/get_together/settings.py
@@ -32,6 +32,7 @@ DEBUG = True
 ALLOWED_HOSTS = []
 SITE_ID = 1
 ADMINS = ["mhall119"]
+ALLOWED_EMAILS_PER_DAY = 100
 
 # Application definition
 


### PR DESCRIPTION
Prevent the use of team and event invitations to external emails from being used to send spam by imposing a limit to the number of email messages a user can send per day

Signed-off-by: Michael Hall <mhall119@gmail.com>