### PR TITLE
Correct spelling of "notification"

### DIFF
--- a/get_together/templates/get_together/new_user/confirm_notifications.html
+++ b/get_together/templates/get_together/new_user/confirm_notifications.html
@@ -8,7 +8,7 @@
             <h2>{% trans "Manage email notifications" %}</h2>
 
             <p>{% blocktrans with email=request.user.email %}GetTogether can send notifications to <strong>{{email}}</strong> about your upcoming events or new events for teams you are a member of.{% endblocktrans %}</p>
-            <p>{% trans "Please confirm whether or not you would like to receive these notifcation emails." %}</p>
+            <p>{% trans "Please confirm whether or not you would like to receive these notification emails." %}</p>
 
             <p>
                 <form action={% url 'confirm-notifications' %} method="POST">


### PR DESCRIPTION
Tiny typo correction on signup.
The corresponding `.pot` file may need to be regenerated; I don't know whether that's supposed to be part of a PR, or if it's done by some automated process.