### PR TITLE
Keep an event's "local time" the same when setting a Place changes it's timezone

### DIFF
--- a/events/models/events.py
+++ b/events/models/events.py
@@ -160,6 +160,18 @@ class Event(models.Model):
         verbose_name=_("Presentations"), default=False
     )
 
+    def set_place(self, place):
+        # Changes an event's place, resetting start and end times to be localtime-consistent
+        old_tz = pytz.timezone(self.tz)
+        naive_start_time = timezone.make_naive(self.start_time, old_tz)
+        naive_end_time = timezone.make_naive(self.end_time, old_tz)
+        self.place = place
+        new_tz = pytz.timezone(self.tz)
+        self.start_time = timezone.make_aware(naive_start_time, new_tz).astimezone(
+            pytz.utc
+        )
+        self.end_time = timezone.make_aware(naive_end_time, new_tz).astimezone(pytz.utc)
+
     @property
     def is_over(self):
         return self.end_time <= timezone.now()

--- a/get_together/templates/get_together/places/create_place.html
+++ b/get_together/templates/get_together/places/create_place.html
@@ -10,7 +10,7 @@
             <form action="{% url "add-place" event.id %}" method="post">
             {% csrf_token %}
             <input type="hidden" id="id_id" name="id" value="" />
-            {% include "events/place_form.html" %}
+                {% include "events/place_form.html" %}
 	            <div class="fluid-layout" id="place-map"></div>
             <br />
             <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>

--- a/get_together/views/events.py
+++ b/get_together/views/events.py
@@ -893,11 +893,11 @@ def add_place_to_event(request, event_id):
         return render(request, "get_together/places/create_place.html", context)
     elif request.method == "POST":
         form = NewPlaceForm(request.POST)
-        if form.is_valid:
+        if form.is_valid():
             if request.POST.get("id", None):
                 form.instance.id = request.POST.get("id")
             new_place = form.save()
-            event.place = new_place
+            event.set_place(new_place)
             event.save()
             if event.series is not None and event.series.place is None:
                 event.series.place = new_place


### PR DESCRIPTION
Shift an event's time when a Place is added with a different timezone so that that the time set by the user remains constant. Fixes #238

Signed-off-by: Michael Hall <mhall119@gmail.com>