### PR TITLE
Mark more strings as translatable

### DIFF
--- a/events/forms.py
+++ b/events/forms.py
@@ -215,7 +215,7 @@ class TeamForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["city"].required = True
-        self.fields["access"].choices = [(0, "Public"), (2, "Private")]
+        self.fields["access"].choices = [(0, _("Public")), (2, _("Private"))]
 
 
 class NewTeamForm(forms.ModelForm):
@@ -228,7 +228,7 @@ class NewTeamForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["city"].required = True
-        self.fields["access"].choices = [(0, "Public"), (2, "Private")]
+        self.fields["access"].choices = [(0, _("Public")), (2, _("Private"))]
 
 
 class TeamDefinitionForm(forms.ModelForm):

--- a/get_together/templates/get_together/events/edit_event.html
+++ b/get_together/templates/get_together/events/edit_event.html
@@ -14,7 +14,7 @@
 {% include "events/event_form.html" %}
 	<br />
 	<a href="{{ event.get_absolute_url }}" class="btn btn-secondary"><i class="fa fa-chevron-left"></i> {% trans "Back" %}</a>
-	<button type="submit" class="btn btn-primary">Update</button>
+	<button type="submit" class="btn btn-primary">{% trans "Update" %}</button>
 </form>
 {% if event.status == event.CANCELED %}
 <a href="{% url 'restore-event' event.id %}" class="btn btn-success">{% trans "Restore" %}</a>

--- a/get_together/templates/get_together/events/manage_attendees.html
+++ b/get_together/templates/get_together/events/manage_attendees.html
@@ -84,13 +84,13 @@
 
         <div class="col-sm-3">
             <div class="container">
-            <h4>Contact</h4><hr/>
+            <h4>{% trans "Contact" %}</h4><hr/>
                 <div class="row">
                     <div class="col">
                         <form action="{% url 'manage-attendees' event.id %}" method="POST">
                             {% csrf_token %}
                             {{ contact_form.as_p }}
-                            <button type="submit" class="btn btn-primary btn-sm">Send</button>
+                            <button type="submit" class="btn btn-primary btn-sm">{% trans "Send" %}</button>
                         </form>
                     </div>
                 </div>

--- a/get_together/templates/get_together/users/login.html
+++ b/get_together/templates/get_together/users/login.html
@@ -17,7 +17,7 @@
                 {% if settings.SOCIAL_AUTH_TWITTER_KEY %}<a class="btn btn-twitter mb-1 col-8" href="{% url 'social:begin' 'twitter' %}?{{ request.META.QUERY_STRING }}"><i class="fab fa-twitter"></i> Twitter</a></br>{% endif %}
                 {% comment %}{% if settings.SOCIAL_AUTH_LINKEDIN_KEY %}<a class="btn btn-linkedin mb-1 col-8" href="{% url 'social:begin' 'linkedin' %}?{{ request.META.QUERY_STRING }}"><i class="fab fa-linkedin"></i> LinkedIn</a></br>{% endif %}{% endcomment %}
                 {% if settings.SOCIAL_AUTH_GITHUB_KEY %}<a class="btn btn-github mb-1 col-8" href="{% url 'social:begin' 'github' %}?{{ request.META.QUERY_STRING }}"><i class="fab fa-github"></i> GitHub</a></br>{% endif %}
-            <p class="text-muted small mt-2">OR</p>
+            <p class="text-muted small mt-2">{% trans "OR" %}</p>
         <div>
             <ul class="nav nav-tabs justify-content-center mb-2" id="localTab" role="tablist">
               <li class="nav-item">
@@ -37,7 +37,7 @@
                     <button class="btn btn-primary" type="submit" name="action" value="login">{% trans "Login" %}</button>
                 </form>
                 <br /><br />
-                <a href="{% url 'password_reset' %}">Forgot my password</a>
+                <a href="{% url 'password_reset' %}">{% trans "Forgot my password" %}</a>
               </div>
               <div class="tab-pane fade {% if action == 'signup' %}show active{% endif %}" id="signup" role="tabpanel" aria-labelledby="signup-tab">
                 <form action="#" method="POST">

--- a/get_together/views/events.py
+++ b/get_together/views/events.py
@@ -316,13 +316,13 @@ def manage_attendees(request, event_id):
         if attendee.user.user.account.is_email_confirmed
     ]
     default_choices = [
-        ("all", "Everyone (%s)" % len(attendee_choices)),
-        ("hosts", "Only Hosts"),
+        ("all", _("Everyone (%s)" % len(attendee_choices))),
+        ("hosts", _("Only Hosts")),
     ]
     if event.is_over:
-        default_choices.append(("attended", "Only Attended"))
+        default_choices.append(("attended", _("Only Attended")))
     else:
-        default_choices.append(("attending", "Only Attending"))
+        default_choices.append(("attending", _("Only Attending")))
 
     if request.method == "POST":
         contact_form = EventContactForm(request.POST)

--- a/get_together/views/teams.py
+++ b/get_together/views/teams.py
@@ -262,8 +262,8 @@ def manage_members(request, team_id):
         if member.user.user.account.is_email_confirmed
     ]
     default_choices = [
-        ("all", "All Members (%s)" % len(member_choices)),
-        ("admins", "Only Administrators"),
+        ("all", _("All Members (%s)" % len(member_choices))),
+        ("admins", _("Only Administrators")),
     ]
     if request.method == "POST":
         contact_form = TeamContactForm(request.POST)


### PR DESCRIPTION
Hello @mhall119 
I found some strings that are not marked as translatable. However there are more untranslated string, which I did find in the source:

- On the start page: *City*
- On the *Edit Team* page, the labels *Description*, *About page*, *Category* (and its options), *City*
- On the *Edit Event Detail* page, the label *Summary*, the *+Add rule* and *+Add date* sections
- On the *Change Host* page, the label *Team*

Can you please check, why do them not get translated?