### PR TITLE
Fix path to static files of favicons in manifest.json

### DIFF
--- a/get_together/static/favicon/site.webmanifest
+++ b/get_together/static/favicon/site.webmanifest
@@ -3,37 +3,37 @@
     "short_name": "GetTogether",
     "icons": [
         {
-            "src": "/android-chrome-36x36.png",
+            "src": "/static/favicon/android-chrome-36x36.png",
             "sizes": "36x36",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-48x48.png",
+            "src": "/static/favicon/android-chrome-48x48.png",
             "sizes": "48x48",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-72x72.png",
+            "src": "/static/favicon/android-chrome-72x72.png",
             "sizes": "72x72",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-96x96.png",
+            "src": "/static/favicon/android-chrome-96x96.png",
             "sizes": "96x96",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-144x144.png",
+            "src": "/static/favicon/android-chrome-144x144.png",
             "sizes": "144x144",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-192x192.png",
+            "src": "/static/favicon/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-256x256.png",
+            "src": "/static/favicon/android-chrome-256x256.png",
             "sizes": "256x256",
             "type": "image/png"
         }


### PR DESCRIPTION
It looks like the path to the files was incorrect.
![image](https://user-images.githubusercontent.com/179964/75822514-60e51d80-5da0-11ea-8128-3319c2ff6758.png)
